### PR TITLE
Add function: be-quiet-funcall

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ Here is another example to prevent `recentf` from showing messages during saving
   (be-quiet-advice-add #'recentf-cleanup))
 ```
 
+### The `be-quiet-funcall` function
+
+Use `be-quiet-funcall` when you want to invoke a function while suppressing all output, including messages and printed text. For instance, to call `message` without displaying anything:
+
+```elisp
+(be-quiet-funcall 'message "You won't see this")
+```
+
+Unlike `be-quiet`, which is a macro and captures output in a temporary buffer for later inspection, `be-quiet-funcall` is a regular function that discards all output entirely. Use it when you do not need to capture or inspect the suppressed output.
+
 ## Frequently asked question
 
 ### Identifying Functions to Silence in Emacs
@@ -139,3 +149,4 @@ Other Emacs packages by the same author:
 - [flymake-bashate.el](https://github.com/jamescherti/flymake-bashate.el): A package that provides a Flymake backend for the bashate Bash script style checker.
 - [flymake-ansible-lint.el](https://github.com/jamescherti/flymake-ansible-lint.el): An Emacs package that offers a Flymake backend for ansible-lint.
 - [inhibit-mouse.el](https://github.com/jamescherti/inhibit-mouse.el): A package that disables mouse input in Emacs, offering a simpler and faster alternative to the disable-mouse package.
+- [enhanced-evil-paredit.el](https://github.com/jamescherti/enhanced-evil-paredit.el): An Emacs package that prevents parenthesis imbalance when using *evil-mode* with *paredit*. It intercepts *evil-mode* commands such as delete, change, and paste, blocking their execution if they would break the parenthetical structure.

--- a/be-quiet.el
+++ b/be-quiet.el
@@ -168,15 +168,36 @@ the current contents of `be-quiet-sink' when called with no arguments."
        (and (buffer-live-p be-quiet-sink)
             (kill-buffer be-quiet-sink)))))
 
+;;;###autoload
+(defun be-quiet-funcall (fn &rest args)
+  "Call FN with ARGS while suppressing all output.
+
+This function evaluates FN with the given ARGS while redirecting output that
+would normally be sent to `standard-output' and suppressing messages produced by
+`message'. It also overrides `write-region' and `load' with custom
+implementations that prevent unintended output.
+
+If `be-quiet-disable' is non-nil, the function behaves like a normal `apply'."
+  (if be-quiet-disable
+      (apply fn args)
+    (let ((inhibit-message t))
+      (cl-letf
+          ;; Override `standard-output' (for `print'), `message',
+          ;; `write-region', `load'.
+          ((standard-output #'ignore)
+           ((symbol-function 'message) #'ignore)
+           ((symbol-function 'write-region) #'be-quiet--write-region)
+           ((symbol-function 'load) #'be-quiet--load))
+        (apply fn args)))))
+
 (defun be-quiet--around-advice (orig-fn &rest args)
   "Advise function to suppress any output of the ORIG-FN function.
-ARGS are the ORIG_-FN function arguments."
-  (be-quiet
-    (apply orig-fn args)))
+ARGS are the ORIG-FN function arguments."
+  (apply #'be-quiet-funcall orig-fn args))
 
 ;;;###autoload
 (defun be-quiet-advice-add (fn)
-  "Advise the the FN function to be quiet."
+  "Advise the FN function to be quiet."
   (advice-add fn :around #'be-quiet--around-advice))
 
 ;;;###autoload

--- a/test/be-quiet-test.el
+++ b/test/be-quiet-test.el
@@ -123,7 +123,7 @@
         (should (s-ends-with? "foo" (be-quiet-current-output)))))
     (should (string= (buffer-string) "")))
   (with-temp-buffer
-    (let ((be-quiet-ignore t)
+    (let ((be-quiet-disable t)
           (standard-output (current-buffer)))
       (be-quiet
         (princ "foo")

--- a/test/be-quiet-test.el
+++ b/test/be-quiet-test.el
@@ -164,5 +164,21 @@
                                   #'be-quiet/test-function-advice)
                  nil)))
 
+(ert-deftest be-quiet/funcall ()
+  "Test `be-quiet-funcall'."
+  (message "world4hello5")
+  (be-quiet-funcall
+   (lambda() (message "Hello1world2")))
+  (with-current-buffer "*Messages*"
+    (should
+     (save-excursion
+       (goto-char (point-min))
+       (re-search-forward "Hello1world2" nil t)))
+
+    (should-not
+     (save-excursion
+       (goto-char (point-min))
+       (re-search-forward "world4hello5" nil t)))))
+
 (provide 'be-quiet-test)
 ;;; be-quiet-test.el ends here

--- a/test/be-quiet-test.el
+++ b/test/be-quiet-test.el
@@ -142,7 +142,6 @@
 
 (ert-deftest be-quiet/add-remove-advice ()
   "Test adding and removing the `be-quiet' advice."
-
   ;; Verify that no advice is present initially
   (should (equal (advice-member-p #'be-quiet--around-advice
                                   #'be-quiet/test-function-advice)
@@ -170,12 +169,12 @@
   (be-quiet-funcall
    (lambda() (message "Hello1world2")))
   (with-current-buffer "*Messages*"
-    (should
+    (should-not
      (save-excursion
        (goto-char (point-min))
        (re-search-forward "Hello1world2" nil t)))
 
-    (should-not
+    (should
      (save-excursion
        (goto-char (point-min))
        (re-search-forward "world4hello5" nil t)))))


### PR DESCRIPTION
This function evaluates FN with the given ARGS while redirecting output that would normally be sent to standard-output and suppressing messages produced by message. It also overrides write-region and load with custom implementations that prevent unintended output.

If be-quiet-disable is non-nil, the function behaves like a normal apply.