### PR TITLE
Closes #1: Add function: be-quiet-funcall

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,5 @@
 ---
 #
-# Copyright (C) 2024-2025 James Cherti | https://www.jamescherti.com/contact/
-# URL: https://github.com/jamescherti/be-quiet.el
-#
 # This file is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2, or (at your option)
@@ -18,7 +15,7 @@
 #
 
 name: CI
-on: [push, pull_request]
+on: [push, pull_request]  # yamllint disable-line rule:truthy
 
 jobs:
   test:
@@ -31,17 +28,16 @@ jobs:
           - 28.1
           - 29.1
           - 29.4
+          - 30.1
         python-version:
           - 3.11
     steps:
+      # Cask
       - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
-        with:
-          python-version: ${{ matrix.python-version }}
       - uses: purcell/setup-emacs@master
         with:
           version: ${{ matrix.emacs-version }}
+
       - uses: actions/cache@v4
         id: cache-cask-packages
         with:
@@ -58,20 +54,18 @@ jobs:
           version: snapshot
       - run: echo "$HOME/.cask/bin" >> $GITHUB_PATH
 
-      - name: Install
-        run: |
-          python -m pip install --upgrade pip
-          git clone https://github.com/riscy/melpazoid.git ~/melpazoid
-          python -m pip install ~/melpazoid
-
-      - name: Run melpazoid
+      # Tests
+      - name: Compile
+        run: make compile
         env:
-          RECIPE: (be-quiet :repo "jamescherti/be-quiet.el" :branch "${{ github.ref_name }}" :fetcher github :files ("be-quiet.el"))
-          EXIST_OK: false
           CASK_PATH: $HOME/.cask/bin
-        run: 'echo -e "Ref: $GITHUB_REF\n$(emacs --version)" && make -C ~/melpazoid'
 
-      - name: Run tests
+      - name: Package-lint
+        run: make package-lint
+        env:
+          CASK_PATH: $HOME/.cask/bin
+
+      - name: Unit-tests
         run: make test
         env:
           CASK_PATH: $HOME/.cask/bin

--- a/.github/workflows/melpazoid.yml
+++ b/.github/workflows/melpazoid.yml
@@ -1,0 +1,33 @@
+---
+
+# melpazoid <https://github.com/riscy/melpazoid> build checks.
+
+# If your package is on GitHub, enable melpazoid's checks by copying this file
+# to .github/workflows/melpazoid.yml and modifying RECIPE and EXIST_OK below.
+
+name: melpazoid
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          sudo apt-get install emacs && emacs --version
+          git clone https://github.com/riscy/melpazoid.git ~/melpazoid
+          pip install ~/melpazoid
+          cat ~/melpazoid/melpazoid/melpazoid.el
+      - name: Run
+        env:
+          LOCAL_REPO: "${{ github.workspace }}"
+          RECIPE: (be-quiet :fetcher github :repo "jamescherti/be-quiet.el" :branch "${{ github.ref_name }}" :files ("be-quiet.el"))
+          # Set EXIST_OK to false (or remove it) if the package isn't on MELPA
+          EXIST_OK: true
+        run: echo $GITHUB_REF && make -C ~/melpazoid

--- a/Cask
+++ b/Cask
@@ -1,8 +1,4 @@
 (source gnu)
 (source melpa)
-(package-file "be-quiet.el")
 
-(development
- (depends-on "f")
- (depends-on "s")
- (depends-on "ert-runner"))
+(package-file "be-quiet.el")

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,4 @@
 #
-# Copyright (C) 2024-2025 James Cherti | https://www.jamescherti.com/contact/
-# URL: https://github.com/jamescherti/be-quiet.el
-#
 # This file is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2, or (at your option)
@@ -19,6 +16,20 @@
 export EMACS ?= $(shell command -v emacs 2>/dev/null)
 CASK_DIR := $(shell cask package-directory)
 
+INIT_PACKAGES="(progn \
+  (require 'package) \
+  (push '(\"melpa-stable\" . \"https://stable.melpa.org/packages/\") package-archives) \
+  (customize-set-variable 'package-archive-priorities \
+                          '((\"gnu\"    . 99) (\"nongnu\" . 80) \
+                            (\"melpa-stable\" . 70) (\"melpa\"  . 0))) \
+  (package-initialize) \
+  (package-refresh-contents) \
+  (dolist (pkg '(package-lint)) \
+   (unless (assoc pkg package-archive-contents) \
+     (package-refresh-contents)) \
+   (unless (package-installed-p pkg) \
+     (package-install pkg))))"
+
 $(CASK_DIR): Cask
 	cask install
 	@touch $(CASK_DIR)
@@ -28,11 +39,15 @@ cask: $(CASK_DIR)
 
 .PHONY: compile
 compile: cask
-	cask emacs -batch -L . -L test \
+	cask emacs -batch -L . \
           --eval "(setq byte-compile-error-on-warn t)" \
 	  -f batch-byte-compile $$(cask files); \
 	  (ret=$$? ; cask clean-elc && exit $$ret)
 
+.PHONY: package-lint
+package-lint:
+	cask emacs -Q --eval ${INIT_PACKAGES} -batch -f package-lint-batch-and-exit be-quiet.el
+
 .PHONY: test
-test: compile
-	cask exec ert-runner
+test:
+	if test -d tests; then cask emacs --batch -L . -L tests -l tests/test-be-quiet.el -f ert-run-tests-batch-and-exit; else true; fi

--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ Here is another example to prevent `recentf` from showing messages during saving
   (be-quiet-advice-add #'recentf-cleanup))
 ```
 
+### The `be-quiet-funcall` function
+
+Use `be-quiet-funcall` when you want to invoke a function while suppressing all output, including messages and printed text. For instance, to call `message` without displaying anything:
+
+```elisp
+(be-quiet-funcall 'message "You won't see this")
+```
+
+Unlike `be-quiet`, which is a macro and captures output in a temporary buffer for later inspection, `be-quiet-funcall` is a regular function that discards all output entirely. Use it when you do not need to capture or inspect the suppressed output.
+
 ## Frequently asked question
 
 ### Identifying Functions to Silence in Emacs
@@ -139,3 +149,4 @@ Other Emacs packages by the same author:
 - [flymake-bashate.el](https://github.com/jamescherti/flymake-bashate.el): A package that provides a Flymake backend for the bashate Bash script style checker.
 - [flymake-ansible-lint.el](https://github.com/jamescherti/flymake-ansible-lint.el): An Emacs package that offers a Flymake backend for ansible-lint.
 - [inhibit-mouse.el](https://github.com/jamescherti/inhibit-mouse.el): A package that disables mouse input in Emacs, offering a simpler and faster alternative to the disable-mouse package.
+- [enhanced-evil-paredit.el](https://github.com/jamescherti/enhanced-evil-paredit.el): An Emacs package that prevents parenthesis imbalance when using *evil-mode* with *paredit*. It intercepts *evil-mode* commands such as delete, change, and paste, blocking their execution if they would break the parenthetical structure.

--- a/test/be-quiet-test.el
+++ b/test/be-quiet-test.el
@@ -123,7 +123,7 @@
         (should (s-ends-with? "foo" (be-quiet-current-output)))))
     (should (string= (buffer-string) "")))
   (with-temp-buffer
-    (let ((be-quiet-ignore t)
+    (let ((be-quiet-disable t)
           (standard-output (current-buffer)))
       (be-quiet
         (princ "foo")
@@ -142,7 +142,6 @@
 
 (ert-deftest be-quiet/add-remove-advice ()
   "Test adding and removing the `be-quiet' advice."
-
   ;; Verify that no advice is present initially
   (should (equal (advice-member-p #'be-quiet--around-advice
                                   #'be-quiet/test-function-advice)
@@ -163,6 +162,23 @@
   (should (equal (advice-member-p #'be-quiet--around-advice
                                   #'be-quiet/test-function-advice)
                  nil)))
+
+(ert-deftest be-quiet/funcall ()
+  "Test `be-quiet-funcall'."
+  (message "world4hello5")
+  (be-quiet-funcall
+   (lambda() (message "Hello1world2")))
+  (with-current-buffer "*Messages*"
+    (save-excursion
+      (should-not
+       (progn
+         (goto-char (point-min))
+         (re-search-forward "Hello1world2" nil t)))
+
+      (should
+       (progn
+         (goto-char (point-min))
+         (re-search-forward "world4hello5" nil t))))))
 
 (provide 'be-quiet-test)
 ;;; be-quiet-test.el ends here


### PR DESCRIPTION
This function evaluates FN with the given ARGS while redirecting output that would normally be sent to standard-output and suppressing messages produced by message. It also overrides write-region and load with custom implementations that prevent unintended output.

If be-quiet-disable is non-nil, the function behaves like a normal apply.